### PR TITLE
Yuri/eng 1110 resolving json scalars handle plain types (#492)

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -1360,11 +1360,14 @@ func (s *Source) compactAndUnNullVariables(input []byte) []byte {
 	return input
 }
 
+// cleanupVariables removes null variables and empty objects from the input if removeNullVariables is true
+// otherwise returns the input as is
 func (s *Source) cleanupVariables(variables []byte, removeNullVariables bool) []byte {
 	cp := make([]byte, len(variables))
 	copy(cp, variables)
 
 	if removeNullVariables {
+		// remove null variables from JSON: {"a":null,"b":1} -> {"b":1}
 		err := jsonparser.ObjectEach(variables, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
 			if dataType == jsonparser.Null {
 				cp = jsonparser.Delete(cp, string(key))
@@ -1374,11 +1377,15 @@ func (s *Source) cleanupVariables(variables []byte, removeNullVariables bool) []
 		if err != nil {
 			return variables
 		}
+
+		// remove empty objects
+		cp = s.removeEmptyObjects(cp)
 	}
 
-	return s.removeEmptyObjects(cp)
+	return cp
 }
 
+// removeEmptyObjects removes empty objects from JSON: {"b": "b", "c": {}} -> {"b": "b"}
 func (s *Source) removeEmptyObjects(variables []byte) []byte {
 	var changed bool
 	for {
@@ -1393,13 +1400,13 @@ func (s *Source) removeEmptyObjects(variables []byte) []byte {
 func (s *Source) replaceEmptyObject(variables []byte) ([]byte, bool) {
 	if i := bytes.Index(variables, []byte(":{}")); i != -1 {
 		end := i + 3
-		hasTrainlingComma := false
+		hasTrailingComma := false
 		if variables[end] == ',' {
 			end++
-			hasTrainlingComma = true
+			hasTrailingComma = true
 		}
 		startQuote := bytes.LastIndex(variables[:i-2], []byte("\""))
-		if !hasTrainlingComma && variables[startQuote-1] == ',' {
+		if !hasTrailingComma && variables[startQuote-1] == ',' {
 			startQuote--
 		}
 		return append(variables[:startQuote], variables[end:]...), true

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -8113,7 +8112,7 @@ func runTestOnTestDefinition(operation, operationName string, expectedPlan plan.
 func TestSource_Load(t *testing.T) {
 	t.Run("unnull_variables", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			body, _ := ioutil.ReadAll(r.Body)
+			body, _ := io.ReadAll(r.Body)
 			_, _ = fmt.Fprint(w, string(body))
 		}))
 		defer ts.Close()
@@ -8124,7 +8123,7 @@ func TestSource_Load(t *testing.T) {
 			variables = []byte(`{"a": null, "b": "b", "c": {}}`)
 		)
 
-		t.Run("should remove null variables when flag is set", func(t *testing.T) {
+		t.Run("should remove null variables and empty objects when flag is set", func(t *testing.T) {
 			var input []byte
 			input = httpclient.SetInputBodyWithPath(input, variables, "variables")
 			input = httpclient.SetInputURL(input, []byte(serverUrl))
@@ -8135,7 +8134,7 @@ func TestSource_Load(t *testing.T) {
 			assert.Equal(t, `{"variables":{"b":"b"}}`, buf.String())
 		})
 
-		t.Run("should only compact variables and remove empty objects when no flag set", func(t *testing.T) {
+		t.Run("should only compact variables when no flag set", func(t *testing.T) {
 			var input []byte
 			input = httpclient.SetInputBodyWithPath(input, variables, "variables")
 			input = httpclient.SetInputURL(input, []byte(serverUrl))
@@ -8143,7 +8142,7 @@ func TestSource_Load(t *testing.T) {
 			buf := bytes.NewBuffer(nil)
 
 			require.NoError(t, src.Load(context.Background(), input, buf))
-			assert.Equal(t, `{"variables":{"a":null,"b":"b"}}`, buf.String())
+			assert.Equal(t, `{"variables":{"a":null,"b":"b","c":{}}}`, buf.String())
 		})
 	})
 }

--- a/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_sse_handler_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -111,7 +111,7 @@ func TestGraphQLSubscriptionClientSubscribe_SSE_POST(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
 
-		actualReqBody, err := ioutil.ReadAll(r.Body)
+		actualReqBody, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedReqBody, actualReqBody)
 
@@ -403,7 +403,7 @@ func TestBuildPOSTRequestSSE(t *testing.T) {
 
 	assert.Equal(t, http.MethodPost, req.Method)
 
-	actualReqBody, err := ioutil.ReadAll(req.Body)
+	actualReqBody, err := io.ReadAll(req.Body)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedReqBody, actualReqBody)
 }

--- a/pkg/engine/resolve/defer_test.go
+++ b/pkg/engine/resolve/defer_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
@@ -112,7 +112,7 @@ func TestWithoutDefer(t *testing.T) {
 	err := resolver.ResolveGraphQLResponse(ctx, res, nil, buf)
 	assert.NoError(t, err)
 
-	expectedBytes, err := ioutil.ReadFile("./testdata/response_without_defer.json")
+	expectedBytes, err := os.ReadFile("./testdata/response_without_defer.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expectedBytes), buf.String())
 	if t.Failed() {
@@ -121,11 +121,11 @@ func TestWithoutDefer(t *testing.T) {
 }
 
 func TestJsonPatch(t *testing.T) {
-	initialResponse, err := ioutil.ReadFile("./testdata/defer_1.json")
+	initialResponse, err := os.ReadFile("./testdata/defer_1.json")
 	assert.NoError(t, err)
-	patch1, err := ioutil.ReadFile("./testdata/defer_2.json")
+	patch1, err := os.ReadFile("./testdata/defer_2.json")
 	assert.NoError(t, err)
-	patch2, err := ioutil.ReadFile("./testdata/defer_3.json")
+	patch2, err := os.ReadFile("./testdata/defer_3.json")
 	assert.NoError(t, err)
 
 	p1, err := jsonpatch.DecodePatch(patch1)
@@ -140,7 +140,7 @@ func TestJsonPatch(t *testing.T) {
 	patched, err = p2.Apply(patched)
 	assert.NoError(t, err)
 
-	expectedBytes, err := ioutil.ReadFile("./testdata/response_without_defer.json")
+	expectedBytes, err := os.ReadFile("./testdata/response_without_defer.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expectedBytes), string(patched))
 	if t.Failed() {
@@ -266,21 +266,21 @@ func TestDefer(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 3, len(writer.flushed))
 
-	expectedBytes, err := ioutil.ReadFile("./testdata/defer_1.json")
+	expectedBytes, err := os.ReadFile("./testdata/defer_1.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expectedBytes), writer.flushed[0])
 	if t.Failed() {
 		fmt.Println(writer.flushed[0])
 	}
 
-	expectedBytes, err = ioutil.ReadFile("./testdata/defer_2.json")
+	expectedBytes, err = os.ReadFile("./testdata/defer_2.json")
 	require.NoError(t, err)
 	assert.JSONEq(t, string(expectedBytes), writer.flushed[1])
 	if t.Failed() {
 		fmt.Println(writer.flushed[1])
 	}
 
-	expectedBytes, err = ioutil.ReadFile("./testdata/defer_3.json")
+	expectedBytes, err = os.ReadFile("./testdata/defer_3.json")
 	require.NoError(t, err)
 	assert.JSONEq(t, string(expectedBytes), writer.flushed[2])
 	if t.Failed() {
@@ -301,9 +301,9 @@ func (d *DiscardFlushWriter) Flush() {
 
 func BenchmarkDefer(b *testing.B) {
 
-	userData, err := ioutil.ReadFile("./testdata/users.json")
+	userData, err := os.ReadFile("./testdata/users.json")
 	assert.NoError(b, err)
-	postsData, err := ioutil.ReadFile("./testdata/posts.json")
+	postsData, err := os.ReadFile("./testdata/posts.json")
 	assert.NoError(b, err)
 
 	userService := FakeDataSource(string(userData))
@@ -401,11 +401,11 @@ func BenchmarkDefer(b *testing.B) {
 	writer := &DiscardFlushWriter{}
 	// writer := &TestFlushWriter{}
 
-	expect1, err := ioutil.ReadFile("./testdata/defer_1.json")
+	expect1, err := os.ReadFile("./testdata/defer_1.json")
 	assert.NoError(b, err)
-	expect2, err := ioutil.ReadFile("./testdata/defer_2.json")
+	expect2, err := os.ReadFile("./testdata/defer_2.json")
 	assert.NoError(b, err)
-	expect3, err := ioutil.ReadFile("./testdata/defer_3.json")
+	expect3, err := os.ReadFile("./testdata/defer_3.json")
 	assert.NoError(b, err)
 
 	_, _, _ = expect1, expect2, expect3
@@ -430,7 +430,7 @@ func BenchmarkDefer(b *testing.B) {
 }
 
 func fakeService(t *testing.T, controller *gomock.Controller, serviceName, responseFilePath string, expectedInput ...string) DataSource {
-	data, err := ioutil.ReadFile(responseFilePath)
+	data, err := os.ReadFile(responseFilePath)
 	assert.NoError(t, err)
 	service := NewMockDataSource(controller)
 	for i := 0; i < len(expectedInput); i++ {

--- a/pkg/engine/resolve/resolve_test.go
+++ b/pkg/engine/resolve/resolve_test.go
@@ -1514,6 +1514,119 @@ func TestResolver_ResolveNode(t *testing.T) {
 			},
 		}, Context{Context: context.Background()}, `{"id":1,"name":"Jens","pet":{"name":"Woofie"}}`
 	}))
+	t.Run("with unescape json enabled", func(t *testing.T) {
+		t.Run("json object within a string", testFn(false, false, func(t *testing.T, ctrl *gomock.Controller) (node Node, ctx Context, expectedOutput string) {
+			return &Object{
+				Fetch: &SingleFetch{
+					BufferId: 0,
+					// Datasource returns a JSON object within a string
+					DataSource: FakeDataSource(`{"data":"{ \"hello\": \"world\" }"}`),
+				},
+				Nullable: false,
+				Fields: []*Field{
+					{
+						Name: []byte("data"),
+						// Value is a string and unescape json is enabled
+						Value: &String{
+							Path:                 []string{"data"},
+							Nullable:             true,
+							UnescapeResponseJson: true,
+							IsTypeName:           false,
+						},
+						Position: Position{
+							Line:   2,
+							Column: 3,
+						},
+						HasBuffer: true,
+					},
+				},
+				// expected output is a JSON object
+			}, Context{Context: context.Background()}, `{"data":{ "hello": "world" }}`
+		}))
+		t.Run("json array within a string", testFn(false, false, func(t *testing.T, ctrl *gomock.Controller) (node Node, ctx Context, expectedOutput string) {
+			return &Object{
+				Fetch: &SingleFetch{
+					BufferId: 0,
+					// Datasource returns a JSON array within a string
+					DataSource: FakeDataSource(`{"data": "[1, 2, 3]"}`),
+				},
+				Nullable: false,
+				Fields: []*Field{
+					{
+						Name: []byte("data"),
+						// Value is a string and unescape json is enabled
+						Value: &String{
+							Path:                 []string{"data"},
+							Nullable:             true,
+							UnescapeResponseJson: true,
+							IsTypeName:           false,
+						},
+						Position: Position{
+							Line:   2,
+							Column: 3,
+						},
+						HasBuffer: true,
+					},
+				},
+				// expected output is a JSON array
+			}, Context{Context: context.Background()}, `{"data":[1, 2, 3]}`
+		}))
+		t.Run("json boolean within a string", testFn(false, false, func(t *testing.T, ctrl *gomock.Controller) (node Node, ctx Context, expectedOutput string) {
+			return &Object{
+				Fetch: &SingleFetch{
+					BufferId: 0,
+					// Datasource returns a JSON boolean within a string
+					DataSource: FakeDataSource(`{"data": "true"}`),
+				},
+				Nullable: false,
+				Fields: []*Field{
+					{
+						Name: []byte("data"),
+						// Value is a string and unescape json is enabled
+						Value: &String{
+							Path:                 []string{"data"},
+							Nullable:             true,
+							UnescapeResponseJson: true,
+							IsTypeName:           false,
+						},
+						Position: Position{
+							Line:   2,
+							Column: 3,
+						},
+						HasBuffer: true,
+					},
+				},
+				// expected output is a JSON boolean
+			}, Context{Context: context.Background()}, `{"data":true}`
+		}))
+		t.Run("handle plain strings", testFn(false, false, func(t *testing.T, ctrl *gomock.Controller) (node Node, ctx Context, expectedOutput string) {
+			return &Object{
+				Fetch: &SingleFetch{
+					BufferId:   0,
+					DataSource: FakeDataSource(`{"data": "hello world"}`),
+				},
+				Nullable: false,
+				Fields: []*Field{
+					{
+						Name: []byte("data"),
+						// Value is a string and unescape json is enabled
+						Value: &String{
+							Path:                 []string{"data"},
+							Nullable:             true,
+							UnescapeResponseJson: true,
+							IsTypeName:           false,
+						},
+						Position: Position{
+							Line:   2,
+							Column: 3,
+						},
+						HasBuffer: true,
+					},
+				},
+				// expect data value to be valid JSON string
+			}, Context{Context: context.Background()}, `{"data":"hello world"}`
+		}))
+	})
 }
 
 func TestResolver_WithHooks(t *testing.T) {

--- a/pkg/engine/resolve/stream_test.go
+++ b/pkg/engine/resolve/stream_test.go
@@ -4,7 +4,7 @@ package resolve
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -80,15 +80,15 @@ func TestArrayStream(t *testing.T) {
 
 	assert.Equal(t, 3, len(writer.flushed))
 
-	expected, err := ioutil.ReadFile("./testdata/stream_1.json")
+	expected, err := os.ReadFile("./testdata/stream_1.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expected), writer.flushed[0])
 
-	expected, err = ioutil.ReadFile("./testdata/stream_2.json")
+	expected, err = os.ReadFile("./testdata/stream_2.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expected), writer.flushed[1])
 
-	expected, err = ioutil.ReadFile("./testdata/stream_3.json")
+	expected, err = os.ReadFile("./testdata/stream_3.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expected), writer.flushed[2])
 }
@@ -176,11 +176,11 @@ func TestArrayStream_InitialBatch_1(t *testing.T) {
 
 	assert.Equal(t, 2, len(writer.flushed))
 
-	expected, err := ioutil.ReadFile("./testdata/stream_4.json")
+	expected, err := os.ReadFile("./testdata/stream_4.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expected), writer.flushed[0])
 
-	expected, err = ioutil.ReadFile("./testdata/stream_3.json")
+	expected, err = os.ReadFile("./testdata/stream_3.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expected), writer.flushed[1])
 }
@@ -268,7 +268,7 @@ func TestArrayStream_InitialBatch_2(t *testing.T) {
 
 	assert.Equal(t, 1, len(writer.flushed))
 
-	expected, err := ioutil.ReadFile("./testdata/stream_5.json")
+	expected, err := os.ReadFile("./testdata/stream_5.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expected), writer.flushed[0])
 }
@@ -389,23 +389,23 @@ func TestStreamAndDefer(t *testing.T) {
 
 	assert.Equal(t, 5, len(writer.flushed))
 
-	expected, err := ioutil.ReadFile("./testdata/stream_1.json")
+	expected, err := os.ReadFile("./testdata/stream_1.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expected), writer.flushed[0])
 
-	expected, err = ioutil.ReadFile("./testdata/stream_6.json")
+	expected, err = os.ReadFile("./testdata/stream_6.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expected), writer.flushed[1])
 
-	expected, err = ioutil.ReadFile("./testdata/stream_7.json")
+	expected, err = os.ReadFile("./testdata/stream_7.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expected), writer.flushed[2])
 
-	expected, err = ioutil.ReadFile("./testdata/stream_8.json")
+	expected, err = os.ReadFile("./testdata/stream_8.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expected), writer.flushed[3])
 
-	expected, err = ioutil.ReadFile("./testdata/stream_9.json")
+	expected, err = os.ReadFile("./testdata/stream_9.json")
 	assert.NoError(t, err)
 	assert.JSONEq(t, string(expected), writer.flushed[4])
 }


### PR DESCRIPTION
* fix: resolver, handle plain types

* fix: datasource, remove empty objects on purpose only

* chore: doc, improve

---

**Stack**:
- #28
- #27
- #26
- #25
- #24
- #23
- #22
- #21
- #20
- #19 ⬅
- #18
- #17
- #16


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*