### PR TITLE
Bug/description blocks with quote (#496)

### DIFF
--- a/pkg/ast/ast_description.go
+++ b/pkg/ast/ast_description.go
@@ -84,9 +84,11 @@ func (d *Document) ImportDescription(desc string) (description Description) {
 		return
 	}
 
+	isBlockString := strings.Contains(desc, "\n") || strings.Contains(desc, `"`)
+
 	return Description{
 		IsDefined:     true,
-		IsBlockString: strings.Contains(desc, "\n"),
+		IsBlockString: isBlockString,
 		Content:       d.Input.AppendInputString(desc),
 	}
 }

--- a/pkg/introspection/fixtures/starwars.golden
+++ b/pkg/introspection/fixtures/starwars.golden
@@ -175,7 +175,9 @@ scalar String
 "The `Boolean` scalar type represents `true` or `false` ."
 scalar Boolean
 
-"The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `4`) or integer (such as 4) input value will be accepted as an ID."
+"""
+The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as "4") or integer (such as 4) input value will be accepted as an ID.
+"""
 scalar ID
 
 "Directs the executor to include this field or fragment only when the argument is true."


### PR DESCRIPTION
Fixed bug where single line triple quoted description contained a quote.

Co-authored-by: Ole Morten Halvorsen <ole@sketch.com>
Co-authored-by: Ole Morten Halvorsen <olemortenh@gmail.com>

---

**Stack**:
- #28
- #27
- #26
- #25
- #24
- #23
- #22 ⬅
- #21
- #20
- #19
- #18
- #17
- #16


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*