### PR TITLE
Improve repeatable directives support (#503)

### DIFF
--- a/pkg/ast/ast_directive.go
+++ b/pkg/ast/ast_directive.go
@@ -175,6 +175,7 @@ func (d *Document) AddDirectiveToNode(directiveRef int, node Node) bool {
 		return true
 	case NodeKindFragmentDefinition:
 		d.FragmentDefinitions[node.Ref].Directives.Refs = append(d.FragmentDefinitions[node.Ref].Directives.Refs, directiveRef)
+		d.FragmentDefinitions[node.Ref].HasDirectives = true
 		return true
 	default:
 		return false
@@ -210,13 +211,4 @@ func (d *Document) DirectiveIsAllowedOnNodeKind(directiveName string, kind NodeK
 	}
 
 	return false
-}
-
-func (d *Document) DirectiveDefinitionByName(name string) (int, bool) {
-	for i := range d.DirectiveDefinitions {
-		if name == d.Input.ByteSliceString(d.DirectiveDefinitions[i].Name) {
-			return i, true
-		}
-	}
-	return -1, false
 }

--- a/pkg/ast/ast_directive_definition.go
+++ b/pkg/ast/ast_directive_definition.go
@@ -133,3 +133,25 @@ func (d *Document) ImportDirectiveDefinition(name, description string, argsRefs 
 
 	return
 }
+
+func (d *Document) DirectiveDefinitionByName(name string) (int, bool) {
+	for i := range d.DirectiveDefinitions {
+		if name == d.Input.ByteSliceString(d.DirectiveDefinitions[i].Name) {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func (d *Document) DirectiveDefinitionByNameBytes(name []byte) (int, bool) {
+	for i := range d.DirectiveDefinitions {
+		if bytes.Equal(name, d.Input.ByteSlice(d.DirectiveDefinitions[i].Name)) {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func (d *Document) DirectiveDefinitionIsRepeatable(ref int) bool {
+	return d.DirectiveDefinitions[ref].Repeatable.IsRepeatable
+}

--- a/pkg/ast/ast_fragment_definition.go
+++ b/pkg/ast/ast_fragment_definition.go
@@ -26,8 +26,9 @@ type FragmentDefinition struct {
 	FragmentLiteral position.Position  // fragment
 	Name            ByteSliceReference // Name but not on, e.g. friendFields
 	TypeCondition   TypeCondition      // e.g. on User
-	Directives      DirectiveList      // optional, e.g. @foo
-	SelectionSet    int                // e.g. { id }
+	HasDirectives   bool
+	Directives      DirectiveList // optional, e.g. @foo
+	SelectionSet    int           // e.g. { id }
 	HasSelections   bool
 }
 

--- a/pkg/astparser/parser.go
+++ b/pkg/astparser/parser.go
@@ -1551,6 +1551,7 @@ func (p *Parser) parseFragmentDefinition() {
 	fragmentDefinition.TypeCondition = p.parseTypeCondition()
 	if p.peekEquals(keyword.AT) {
 		fragmentDefinition.Directives = p.parseDirectiveList()
+		fragmentDefinition.HasDirectives = len(fragmentDefinition.Directives.Refs) > 0
 	}
 	fragmentDefinition.SelectionSet, fragmentDefinition.HasSelections = p.parseSelectionSet()
 	p.document.FragmentDefinitions = append(p.document.FragmentDefinitions, fragmentDefinition)

--- a/pkg/astprinter/astprinter_test.go
+++ b/pkg/astprinter/astprinter_test.go
@@ -114,7 +114,8 @@ directive @cache(
   Examples: 'jwt.sub', 'jwt.team' to vary the cache key based on 'sub' or 'team' fields on the jwt. 
   """
   vary: [String]! = []
-) on QUERY`,
+) on QUERY directive @include(if: Boolean!) repeatable on FIELD
+`,
 			`"""
 directive @cache
 """
@@ -124,7 +125,14 @@ vary defines the headers to append to the cache key
 In addition to all possible headers you can also select a custom claim for authenticated requests
 Examples: 'jwt.sub', 'jwt.team' to vary the cache key based on 'sub' or 'team' fields on the jwt.
 """
-vary: [String]! = []) on QUERY`)
+vary: [String]! = []) on QUERY directive @include(if: Boolean!) repeatable on FIELD`)
+	})
+	t.Run("fragment definition with directives", func(t *testing.T) {
+		run(t, `
+			fragment foo on Dog @fragmentDefinition {
+				name
+			}
+		`, `fragment foo on Dog @fragmentDefinition {name}`)
 	})
 	t.Run("anonymous query", func(t *testing.T) {
 		run(t, `	{

--- a/pkg/astvalidation/definition_validation.go
+++ b/pkg/astvalidation/definition_validation.go
@@ -18,6 +18,7 @@ func DefaultDefinitionValidator() *DefinitionValidator {
 		RequireDefinedTypesForExtensions(),
 		ImplementTransitiveInterfaces(),
 		ImplementingTypesAreSupersets(),
+		DirectivesAreUniquePerLocation(),
 	)
 }
 
@@ -46,7 +47,7 @@ func (d *DefinitionValidator) Validate(definition *ast.Document, report *operati
 		report = &operationreport.Report{}
 	}
 
-	d.walker.Walk(definition, nil, report)
+	d.walker.Walk(definition, definition, report)
 
 	if report.HasErrors() {
 		return Invalid

--- a/pkg/astvalidation/operation_rule_directives_unique_per_location.go
+++ b/pkg/astvalidation/operation_rule_directives_unique_per_location.go
@@ -22,24 +22,46 @@ func DirectivesAreUniquePerLocation() Rule {
 type directivesAreUniquePerLocationVisitor struct {
 	*astvisitor.Walker
 	operation, definition *ast.Document
+	seenDuplicates        map[int]struct{}
 }
 
 func (d *directivesAreUniquePerLocationVisitor) EnterDocument(operation, definition *ast.Document) {
 	d.operation = operation
 	d.definition = definition
+	d.seenDuplicates = make(map[int]struct{})
 }
 
 func (d *directivesAreUniquePerLocationVisitor) EnterDirective(ref int) {
+	if _, seen := d.seenDuplicates[ref]; seen {
+		// skip directive reported as duplicate
+		return
+	}
 
 	directiveName := d.operation.DirectiveNameBytes(ref)
-	directives := d.operation.NodeDirectives(d.Ancestors[len(d.Ancestors)-1])
 
-	for _, j := range directives {
+	directiveDefRef, exists := d.definition.DirectiveDefinitionByNameBytes(directiveName)
+	if !exists {
+		// ignore unknown directives
+		return
+	}
+
+	if d.definition.DirectiveDefinitionIsRepeatable(directiveDefRef) {
+		// ignore repeatable directives
+		return
+	}
+
+	nodeDirectives := d.operation.NodeDirectives(d.Ancestors[len(d.Ancestors)-1])
+	for _, j := range nodeDirectives {
 		if j == ref {
 			continue
 		}
 		if bytes.Equal(directiveName, d.operation.DirectiveNameBytes(j)) {
-			d.StopWithExternalErr(operationreport.ErrDirectiveMustBeUniquePerLocation(directiveName))
+			d.seenDuplicates[j] = struct{}{}
+			d.Report.AddExternalError(operationreport.ErrDirectiveMustBeUniquePerLocation(
+				directiveName,
+				d.operation.Directives[ref].At,
+				d.operation.Directives[j].At,
+			))
 			return
 		}
 	}

--- a/pkg/astvalidation/reference/testsgo/UniqueDirectivesPerLocationRule_test.go
+++ b/pkg/astvalidation/reference/testsgo/UniqueDirectivesPerLocationRule_test.go
@@ -5,13 +5,17 @@ import (
 )
 
 func TestUniqueDirectivesPerLocationRule(t *testing.T) {
-	t.Skip()
 
 	extensionSDL := `
   directive @directive on FIELD | FRAGMENT_DEFINITION
   directive @directiveA on FIELD | FRAGMENT_DEFINITION
   directive @directiveB on FIELD | FRAGMENT_DEFINITION
   directive @repeatable repeatable on FIELD | FRAGMENT_DEFINITION
+
+  # adding type here to make test queries valid
+  type Type {
+    field: String!
+  }
 `
 	schemaWithDirectives := ExtendSchema(testSchema, extensionSDL)
 
@@ -245,7 +249,7 @@ func TestUniqueDirectivesPerLocationRule(t *testing.T) {
 		})
 
 		t.Run("duplicate directives on SDL extensions", func(t *testing.T) {
-			t.Skip("Parser do not support repeatable directives")
+			t.Skip("Parser do not support directives on extensions")
 
 			ExpectSDLErrors(t, `
       directive @nonRepeatable on
@@ -305,7 +309,7 @@ func TestUniqueDirectivesPerLocationRule(t *testing.T) {
 		})
 
 		t.Run("duplicate directives between SDL definitions and extensions", func(t *testing.T) {
-			t.Skip("Parser do not support repeatable directives")
+			t.Skip("Parser do not support directives on extensions")
 
 			ExpectSDLErrors(t, `
       directive @nonRepeatable on SCHEMA

--- a/pkg/astvalidation/reference/testsgo/harness_test.go
+++ b/pkg/astvalidation/reference/testsgo/harness_test.go
@@ -238,9 +238,11 @@ func ExpectValidationErrorMessage(t *testing.T, schema string, queryStr string) 
 // ExtendSchema - helper to extend schema with provided sdl
 //nolint:unused
 func ExtendSchema(schema string, sdlStr string) string {
-	definition := prepareSchema(schema)
+	if sdlStr != "" {
+		schema = schema + "\n" + sdlStr
+	}
 
-	definition.Input.AppendInputBytes([]byte(sdlStr))
+	definition := prepareSchema(schema)
 	parser := astparser.NewParser()
 	report := operationreport.Report{}
 	parser.Parse(&definition, &report)

--- a/pkg/astvisitor/simplevisitor.go
+++ b/pkg/astvisitor/simplevisitor.go
@@ -301,6 +301,12 @@ func (w *SimpleWalker) walkFragmentDefinition(ref int) {
 
 	w.appendAncestor(ref, ast.NodeKindFragmentDefinition)
 
+	if w.document.FragmentDefinitions[ref].HasDirectives {
+		for _, i := range w.document.FragmentDefinitions[ref].Directives.Refs {
+			w.walkDirective(i)
+		}
+	}
+
 	if w.document.FragmentDefinitions[ref].HasSelections {
 		w.walkSelectionSet(w.document.FragmentDefinitions[ref].SelectionSet)
 	}

--- a/pkg/astvisitor/visitor.go
+++ b/pkg/astvisitor/visitor.go
@@ -2093,6 +2093,12 @@ func (w *Walker) walkFragmentDefinition(ref int) {
 		return
 	}
 
+	if w.document.FragmentDefinitions[ref].HasDirectives {
+		for _, i := range w.document.FragmentDefinitions[ref].Directives.Refs {
+			w.walkDirective(i)
+		}
+	}
+
 	if w.document.FragmentDefinitions[ref].HasSelections {
 		w.walkSelectionSet(w.document.FragmentDefinitions[ref].SelectionSet)
 		if w.stop {

--- a/pkg/lexer/literal/literal.go
+++ b/pkg/lexer/literal/literal.go
@@ -61,6 +61,7 @@ var (
 	UNION                         = []byte("union")
 	ENUM                          = []byte("enum")
 	DIRECTIVE                     = []byte("directive")
+	REPEATABLE                    = []byte("repeatable")
 	QUERY                         = []byte("query")
 	MUTATION                      = []byte("mutation")
 	SUBSCRIPTION                  = []byte("subscription")


### PR DESCRIPTION
* add directive repeatable keyword to astprinter

* add HasDirectives to fragment definition
walk directive on framgent definitions

* fix unique directives validation rule to support repeatable
add location to uniq directive error
partially enable reference test for uniq directives validation

* cleanup

* pass definition as definition to definition validator
enable test for sdl validation
add uniq directive to definition validator

---

**Stack**:
- #28
- #27
- #26
- #25 ⬅
- #24
- #23
- #22
- #21
- #20
- #19
- #18
- #17
- #16


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*