### PR TITLE
Fix/validation subgrph (#504)

### DIFF
--- a/pkg/astvalidation/rule_known_type_names.go
+++ b/pkg/astvalidation/rule_known_type_names.go
@@ -20,6 +20,7 @@ func KnownTypeNames() Rule {
 		walker.RegisterEnterUnionMemberTypeVisitor(visitor)
 		walker.RegisterEnterInputValueDefinitionVisitor(visitor)
 		walker.RegisterEnterObjectTypeDefinitionVisitor(visitor)
+		walker.RegisterEnterObjectTypeExtensionVisitor(visitor)
 		walker.RegisterEnterInterfaceTypeDefinitionVisitor(visitor)
 		walker.RegisterEnterScalarTypeDefinitionVisitor(visitor)
 		walker.RegisterEnterUnionTypeDefinitionVisitor(visitor)
@@ -57,7 +58,7 @@ func (u *knownTypeNamesVisitor) EnterRootOperationTypeDefinition(ref int) {
 }
 
 func (u *knownTypeNamesVisitor) EnterFieldDefinition(ref int) {
-	referencedTypeRef := u.definition.FieldDefinitions[ref].Type
+	referencedTypeRef := u.definition.ResolveUnderlyingType(u.definition.FieldDefinitions[ref].Type)
 	referencedTypeName := u.definition.TypeNameBytes(referencedTypeRef)
 	u.saveReferencedTypeName(referencedTypeName)
 }
@@ -75,6 +76,11 @@ func (u *knownTypeNamesVisitor) EnterInputValueDefinition(ref int) {
 
 func (u *knownTypeNamesVisitor) EnterObjectTypeDefinition(ref int) {
 	typeName := u.definition.ObjectTypeDefinitionNameBytes(ref)
+	u.saveTypeName(typeName)
+}
+
+func (u *knownTypeNamesVisitor) EnterObjectTypeExtension(ref int) {
+	typeName := u.definition.ObjectTypeExtensionNameBytes(ref)
 	u.saveTypeName(typeName)
 }
 

--- a/pkg/federation/sdlmerge/testdata/validate-subgraph/lack-definition-non-null.graphqls
+++ b/pkg/federation/sdlmerge/testdata/validate-subgraph/lack-definition-non-null.graphqls
@@ -1,0 +1,16 @@
+type Review {
+    body: String!
+    author: User! @provides(fields: "username")
+    product: Product!
+}
+
+#type User @key(fields: "id") {
+#    id: ID! @external
+#    username: String! @external
+#    reviews: [Review]
+#}
+
+extend type Product @key(fields: "upc") {
+    upc: String! @external
+    reviews: [Review]
+}

--- a/pkg/federation/sdlmerge/testdata/validate-subgraph/lack-definition.graphqls
+++ b/pkg/federation/sdlmerge/testdata/validate-subgraph/lack-definition.graphqls
@@ -1,0 +1,16 @@
+type Review {
+    body: String!
+    author: User @provides(fields: "username")
+    product: Product
+}
+
+#type User @key(fields: "id") {
+#    id: ID! @external
+#    username: String! @external
+#    reviews: [Review]
+#}
+
+extend type Product @key(fields: "upc") {
+    upc: String! @external
+    reviews: [Review]
+}

--- a/pkg/federation/sdlmerge/testdata/validate-subgraph/lack-extend-definition-non-null.graphqls
+++ b/pkg/federation/sdlmerge/testdata/validate-subgraph/lack-extend-definition-non-null.graphqls
@@ -1,0 +1,16 @@
+type Review {
+    body: String!
+    author: User! @provides(fields: "username")
+    product: Product!
+}
+
+type User @key(fields: "id") {
+    id: ID! @external
+    username: String! @external
+    reviews: [Review]
+}
+
+#extend type Product @key(fields: "upc") {
+#    @external
+#    reviews: [Review] }
+#}

--- a/pkg/federation/sdlmerge/testdata/validate-subgraph/lack-extend-definition.graphqls
+++ b/pkg/federation/sdlmerge/testdata/validate-subgraph/lack-extend-definition.graphqls
@@ -1,0 +1,17 @@
+type Review {
+    body: String!
+    author: User @provides(fields: "username")
+    product: Product
+}
+
+type User @key(fields: "id") {
+    id: ID! @external
+    username: String! @external
+    reviews: [Review]
+}
+
+#extend type Product @key(fields: "upc") {
+#    upc: String! @external
+#    reviews: [Review]
+#}
+

--- a/pkg/federation/sdlmerge/testdata/validate-subgraph/well-defined-non-null.graphqls
+++ b/pkg/federation/sdlmerge/testdata/validate-subgraph/well-defined-non-null.graphqls
@@ -1,0 +1,16 @@
+type Review {
+    body: String!
+    author: User! @provides(fields: "username")
+    product: Product!
+}
+
+type User @key(fields: "id") {
+    id: ID! @external
+    username: String! @external
+    reviews: [Review]
+}
+
+extend type Product @key(fields: "upc") {
+    upc: String! @external
+    reviews: [Review]
+}

--- a/pkg/federation/sdlmerge/testdata/validate-subgraph/well-defined.graphqls
+++ b/pkg/federation/sdlmerge/testdata/validate-subgraph/well-defined.graphqls
@@ -1,0 +1,16 @@
+type Review {
+    body: String!
+    author: User @provides(fields: "username")
+    product: Product
+}
+
+type User @key(fields: "id") {
+    id: ID! @external
+    username: String! @external
+    reviews: [Review]
+}
+
+extend type Product @key(fields: "upc") {
+    upc: String! @external
+    reviews: [Review]
+}


### PR DESCRIPTION
* chore: Add tests for validate subgraphs

* fix: Fix to refer to the body of the field type definition if ofType is available

* fix: Fix to add the object-type-extension visitor to the KnownTypeNames rule

* chore: Adjust the data for the test of TestMergeSDLs

* use resolve underlying type helper
use filepath to build a path to a testcase schema

* add check for exact err messages

---------

Co-authored-by: ikawaha <ikawaha@users.noreply.github.com>

---

**Stack**:
- #28
- #27
- #26 ⬅
- #25
- #24
- #23
- #22
- #21
- #20
- #19
- #18
- #17
- #16


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*